### PR TITLE
CircleCi Setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:7.10
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: yarn install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+        
+      # run build!
+      - run: yarn build
+
+      # run tests!
+      - run: yarn test
+
+
+

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "devDependencies": {
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.6.0",
-    "jest": "^23.6.0",
     "jest-enzyme": "^7.0.0",
     "react-test-renderer": "^16.5.2"
   }

--- a/src/translator.js
+++ b/src/translator.js
@@ -3,7 +3,7 @@ import itTranslations from './translations/it';
 import enTranslations from './translations/en';
 
 
-var [lang, locale] = (((navigator.userLanguage || navigator.language).replace('-', '_')).toLowerCase()).split('_');
+var [lang] = (((navigator.userLanguage || navigator.language).replace('-', '_')).toLowerCase()).split('_');
 var polyglot = new Polyglot(lang);
 
 switch (lang) {


### PR DESCRIPTION
## Summary of changes

- CircleCI configuration was added
- An unused variable has been removed since it was causing the build to fail (warnings are treated as errors in CI environment)
- The jest dependency was removed since it comes out of the box when working with react-scripts (and it was causing the tests to fail)

Also, you will have to login on CircleCI and enable the project there. I had enabled on my fork. Once it's enabled the builds will start automatically when code is pushed.

Solves #8 