### PR TITLE
closes #9 - copy email to clipboard when page first renders

### DIFF
--- a/src/Mail.js
+++ b/src/Mail.js
@@ -32,6 +32,16 @@ class Mail extends Component {
     this.notify();
   };
 
+  componentDidMount = () => {
+    navigator.clipboard.writeText(document.getElementById('email').value)
+    .then(() => {
+      this.notify();
+    })
+    .catch((err) => {
+      console.error('could not copy to clipboard ', err);
+    });
+  }
+
   render() {
     return (
       <div>


### PR DESCRIPTION
componentDidMount excutes once, after the page has rendered successfully.