### PR TITLE
Email is copied to clipboard whenever a new email is generated.

### DIFF
--- a/src/Mail.js
+++ b/src/Mail.js
@@ -14,6 +14,9 @@ class Mail extends Component {
     };
   }
 
+
+
+
   notify = () => {
     toast(polyglot.t('copied'), {
       position: toast.POSITION.BOTTOM_LEFT
@@ -24,6 +27,19 @@ class Mail extends Component {
     this.setState({ word: gen(this.state.lengthWord) });
   };
 
+  
+
+  componentDidUpdate(prevProps,prevState,snapshot){ //for copying email when a new email is generated
+
+    const email = document.getElementById('email');
+    email.select();
+    document.execCommand('copy');
+    this.notify();
+
+  }
+
+  
+
   copy = () => {
     console.log('prova');
     const email = document.getElementById('email');
@@ -33,6 +49,7 @@ class Mail extends Component {
   };
 
   render() {
+
     return (
       <div>
         <div className="mail__box">
@@ -46,7 +63,7 @@ class Mail extends Component {
             />
           </div>
           <div className="mail__buttons">
-            <button className="button" onClick={this.copy}>
+            <button className="button">
               {polyglot.t('copy')}{' '}
               <span role="img" aria-label="sheet">
                 📄

--- a/src/Mail.js
+++ b/src/Mail.js
@@ -27,17 +27,16 @@ class Mail extends Component {
     this.setState({ word: gen(this.state.lengthWord) });
   };
 
-  
 
-  componentDidUpdate(prevProps,prevState,snapshot){ //for copying email when a new email is generated
+  change=()=>{
 
+    console.log('prova');
     const email = document.getElementById('email');
     email.select();
     document.execCommand('copy');
     this.notify();
 
   }
-
   
 
   copy = () => {
@@ -47,6 +46,12 @@ class Mail extends Component {
     document.execCommand('copy');
     this.notify();
   };
+
+  componentDidUpdate(prevProps,prevState,snapshot){ //for copying email when a new email is generated
+
+    this.copy();
+
+  }
 
   render() {
 
@@ -59,11 +64,12 @@ class Mail extends Component {
               type="email"
               id="email"
               value={this.state.word + this.state.suffix}
+              onClick={console.log("abcd")}
               readOnly
             />
           </div>
           <div className="mail__buttons">
-            <button className="button">
+            <button className="button" onClick={this.copy}>
               {polyglot.t('copy')}{' '}
               <span role="img" aria-label="sheet">
                 📄


### PR DESCRIPTION
Email is now automatically copied to clipboard whenever a new one is generated. However copying the email as soon as webpages loads is not possible as browser only allows that once the user clicks or fires a click event. I tried to generate events, but that is also not working.